### PR TITLE
Use mineable/pickaxe tag for better support

### DIFF
--- a/src/main/resources/data/digs_dnd_origins/powers/dwarf/hill/tool_proficiency.json
+++ b/src/main/resources/data/digs_dnd_origins/powers/dwarf/hill/tool_proficiency.json
@@ -6,11 +6,8 @@
   "wood_pick": {
     "type": "origins:modify_harvest",
     "block_condition": {
-      "type": "origins:material",
-      "materials": [
-        "stone",
-        "metal"
-      ]
+      "type": "origins:in_tag",
+      "tag": "minecraft:mineable/pickaxe"
     },
     "allow": true,
     "condition": {

--- a/src/main/resources/data/digs_dnd_origins/powers/dwarf/mountain/tool_proficiency.json
+++ b/src/main/resources/data/digs_dnd_origins/powers/dwarf/mountain/tool_proficiency.json
@@ -6,11 +6,8 @@
   "wood_pick": {
     "type": "origins:modify_harvest",
     "block_condition": {
-      "type": "origins:material",
-      "materials": [
-        "stone",
-        "metal"
-      ]
+      "type": "origins:in_tag",
+      "tag": "minecraft:mineable/pickaxe"
     },
     "allow": true,
     "condition": {


### PR DESCRIPTION
Most mods do not support the resources that origins provides, however since tool proficiency applies to all pickaxe mineable resources, better support can be achieved by using the mineable/pickaxe tag from Minecraft itself, as more mods will support this tag.